### PR TITLE
Add README files for submodules and global project

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,36 @@
-# kuick
-
 [![Build Status](https://github.com/gokoan/kuick/workflows/CI+with+Gradle/badge.svg)](https://travis-ci.org/NoSpoonLab/kuick)
+# Kuick Libraries
+
+Kuick is a collection of Kotlin multiplatform libraries designed to accelerate application development by providing robust, reusable components for common tasks.
+
+## Overview
+
+The Kuick project is organized into several submodules, each targeting a specific area of functionality. These libraries aim to be lightweight, easy to use, and extensible.
+
+## Submodules
+
+Here's a brief overview of the available submodules:
+
+*   **[`kuick-core/`](kuick-core/README.md)**: The core module providing essential building blocks such as:
+    *   A flexible repository pattern for data persistence.
+    *   Caching mechanisms.
+    *   An event bus system.
+    *   Logging utilities.
+    *   Various other utilities for models, time, and more.
+    *   [Read more...](kuick-core/README.md)
+
+*   **[`kuick-api-rpc/`](kuick-api-rpc/README.md)**: Facilitates RPC-style (Remote Procedure Call) communication.
+    *   Provides tools to define remote API contracts and clients to consume them.
+    *   [Read more...](kuick-api-rpc/README.md)
+
+*   **[`kuick-repositories-jasync-sql/`](kuick-repositories-jasync-sql/README.md)**: A JVM-specific implementation of the `kuick-core` repository pattern.
+    *   Uses [JAsync SQL](https://github.com/jasync-sql/jasync-sql) for asynchronous database access, primarily targeting PostgreSQL.
+    *   [Read more...](kuick-repositories-jasync-sql/README.md)
+
+## Getting Started
+
+To use a Kuick library in your project, you'll typically add it as a dependency in your `build.gradle` or `build.gradle.kts` file. Please refer to the individual submodule READMEs for specific setup instructions and usage examples.
+
+## Contributing
+
+Contributions are welcome! If you'd like to contribute, please fork the repository and submit a pull request.

--- a/kuick-api-rpc/README.md
+++ b/kuick-api-rpc/README.md
@@ -1,0 +1,76 @@
+# Kuick API RPC
+
+This submodule provides tools and abstractions for facilitating RPC-style communication between different parts of an application or between different services.
+
+## Overview
+
+The main components of this submodule are:
+
+*   **`RpcClient`**: An interface that defines the contract for sending RPC requests and receiving responses. Concrete implementations of this interface handle the actual communication mechanism (e.g., HTTP, WebSockets).
+*   **`AbstractRemoteApi`**: An abstract class that simplifies the creation of RPC client proxies. It uses an `RpcClient` to perform remote calls and handles the serialization/deserialization of data.
+
+## Usage Example
+
+Here's a simple example of how to use these components:
+
+1.  **Define a service interface**:
+
+    ```kotlin
+    interface MyService {
+        suspend fun greet(name: String): String
+        suspend fun add(a: Int, b: Int): Int
+    }
+    ```
+
+2.  **Create a client class**:
+
+    This class extends `AbstractRemoteApi` and implements your service interface.
+
+    ```kotlin
+    import com.kuick.api.rpc.AbstractRemoteApi
+    import com.kuick.api.rpc.RpcClient
+
+    class MyServiceClient(rpcClient: RpcClient) : AbstractRemoteApi(rpcClient), MyService {
+        override suspend fun greet(name: String): String {
+            return call("greet", name)
+        }
+
+        override suspend fun add(a: Int, b: Int): Int {
+            return call("add", a, b)
+        }
+    }
+    ```
+
+3.  **Instantiate and use the client**:
+
+    You'll need a concrete implementation of `RpcClient`. For this example, let's assume you have one called `HttpRpcClient`.
+
+    ```kotlin
+    import com.kuick.api.rpc.RpcClient // Assuming HttpRpcClient is in this package or similar
+
+    suspend fun main() {
+        // Replace with your actual RpcClient implementation
+        val rpcClient: RpcClient = HttpRpcClient("http://your-service-url/api") 
+
+        val myServiceClient = MyServiceClient(rpcClient)
+
+        try {
+            val greeting = myServiceClient.greet("World")
+            println("Server says: $greeting") // Expected: Server says: Hello, World! (or similar)
+
+            val sum = myServiceClient.add(5, 3)
+            println("5 + 3 = $sum") // Expected: 5 + 3 = 8
+        } catch (e: Exception) {
+            println("Error during RPC call: ${e.message}")
+        }
+    }
+    ```
+
+## Integration with other Kuick Libraries
+
+This `kuick-api-rpc` submodule provides the core abstractions for RPC. It is often used in conjunction with other Kuick libraries that offer concrete `RpcClient` implementations, such as:
+
+*   `kuick-api-rpc-ktor-client`: For Ktor-based HTTP clients.
+*   Other libraries providing clients for different protocols or frameworks.
+
+By using these libraries together, you can easily set up RPC communication in your Kuick applications.

--- a/kuick-core/README.md
+++ b/kuick-core/README.md
@@ -1,0 +1,241 @@
+# Kuick Core
+
+`kuick-core` provides essential building blocks and utilities that form the foundation for application development within the Kuick ecosystem. It offers a set of common abstractions and implementations for everyday tasks, promoting consistency and reducing boilerplate code.
+
+## Key Features
+
+Here are some of the core features provided by `kuick-core`:
+
+### Repositories
+
+Repositories in Kuick provide an abstraction layer for data access, making it easier to manage and interact with your data sources.
+
+*   **`Repository<I : Any, T : Any>`**: A generic interface for basic CRUD (Create, Read, Update, Delete) operations on entities of type `T` with identifiers of type `I`.
+*   **`ModelRepository<I : Any, T : Model<I>>`**: A specialized repository for entities that implement the `Model<I>` interface (which typically means they have an `id` property).
+
+**Example:**
+
+```kotlin
+import com.kuick.core.db.ModelRepository
+import com.kuick.core.db.Repository
+import com.kuick.models.Id
+import com.kuick.models.Model
+
+// 1. Define a simple data model
+data class User(override val id: Id<User> = Id(), val name: String, val email: String) : Model<Id<User>>
+
+// 2. Define a repository for the User model
+interface UserRepository : ModelRepository<Id<User>, User> {
+    suspend fun findByEmail(email: String): User?
+}
+
+// 3. Example of using a (hypothetical) UserRepository implementation
+suspend fun demonstrateRepositories(userRepo: UserRepository) {
+    // Insert a new user
+    val newUser = User(name = "Alice", email = "alice@example.com")
+    val insertedUser = userRepo.insert(newUser)
+    println("Inserted user: $insertedUser")
+
+    // Find a user by ID
+    val foundUser = userRepo.findById(insertedUser.id)
+    println("Found user by ID: $foundUser")
+
+    // Find a user by email (custom method)
+    val userByEmail = userRepo.findByEmail("alice@example.com")
+    println("Found user by email: $userByEmail")
+}
+```
+
+### Caching
+
+`kuick-core` provides a simple yet effective caching mechanism to improve performance by storing and reusing the results of expensive operations.
+
+*   **`Cache<K : Any, V : Any>`**: An interface defining basic cache operations like `get`, `set`, and `invalidate`.
+*   **`CacheManager`**: A class that manages different cache instances and provides convenient extension functions like `cached` for easy memoization.
+
+**Example:**
+
+```kotlin
+import com.kuick.core.cache.CacheManager
+import com.kuick.core.cache.GuavaCache // Example implementation
+import kotlinx.coroutines.delay
+
+suspend fun demonstrateCaching(cacheManager: CacheManager) {
+    // Example of a function whose result we want to cache
+    suspend fun expensiveOperation(key: String): String {
+        println("Performing expensive operation for key: $key")
+        delay(1000) // Simulate work
+        return "Result for $key"
+    }
+
+    // Using the 'cached' function
+    // The first call will execute expensiveOperation
+    val result1 = cacheManager.cached("myCache", "dataKey1") {
+        expensiveOperation("dataKey1")
+    }
+    println(result1)
+
+    // The second call with the same key will return the cached result
+    val result2 = cacheManager.cached("myCache", "dataKey1") {
+        expensiveOperation("dataKey1") // This won't be printed again
+    }
+    println(result2)
+
+    // Different key, will execute the operation again
+    val result3 = cacheManager.cached("myCache", "dataKey2") {
+        expensiveOperation("dataKey2")
+    }
+    println(result3)
+}
+
+// To run the example, you'd need to initialize CacheManager, e.g.:
+// val cacheManager = CacheManager()
+// cacheManager.getCache<String, String>("myCache") { GuavaCache() } // Or any other Cache impl
+// demonstrateCaching(cacheManager)
+```
+
+### Event Bus
+
+The `Bus` interface provides a simple publish-subscribe mechanism for decoupled communication between different parts of an application.
+
+*   **`Bus`**: An interface with `publish` and `subscribe` methods. Events are published to the bus, and interested subscribers react to them.
+
+**Example:**
+
+```kotlin
+import com.kuick.core.bus.Bus
+import com.kuick.core.bus.InmemoryBus // Example implementation
+import kotlinx.coroutines.GlobalScope
+import kotlinx.coroutines.launch
+
+// 1. Define an event class
+data class MessageEvent(val message: String)
+
+suspend fun demonstrateEventBus() {
+    val eventBus: Bus = InmemoryBus() // Use an actual implementation
+
+    // 2. Subscribe to an event
+    eventBus.subscribe(MessageEvent::class) { event ->
+        println("Received event: ${event.message}")
+    }
+
+    // 3. Publish an event
+    println("Publishing event...")
+    eventBus.publish(MessageEvent("Hello from the Event Bus!"))
+
+    // Give some time for the event to be processed in async scenarios
+    kotlinx.coroutines.delay(100)
+}
+```
+
+### Logging
+
+`kuick-core` includes a simple logging facade that allows you to integrate with various logging implementations.
+
+*   **`Logger`**: An interface for logging messages at different levels (trace, debug, info, warn, error).
+*   Configuration is typically handled by the underlying logging framework chosen (e.g., Logback, SLF4J). `StaticLoggerContext` allows for basic static configuration.
+
+**Example:**
+
+```kotlin
+import com.kuick.core.logger.Level
+import com.kuick.core.logger.LogRecord
+import com.kuick.core.logger.Logger
+import com.kuick.core.logger.LoggingContext // For potential context setup
+import com.kuick.core.logger.format.PatternLogFormatter // Example formatter
+import com.kuick.core.logger.appender.ConsoleAppender // Example appender
+import com.kuick.core.logger.config.LoggerConfig
+import com.kuick.core.logger.config.LoggingConfiguration
+import com.kuick.core.logger.getLogger
+
+// Basic setup (in a real app, this might be more sophisticated or auto-configured)
+object MyLoggerConfig {
+    fun setup() {
+        val config = LoggingConfiguration().apply {
+            addAppender(ConsoleAppender(PatternLogFormatter()))
+            addLogger(LoggerConfig("", Level.INFO)) // Default root logger level
+            addLogger(LoggerConfig("com.example", Level.DEBUG))
+        }
+        // In a real app, you'd apply this configuration to your logging system.
+        // For kuick-core's basic logger, this might involve StaticLoggerContext or similar.
+        // As kuick-core is a facade, the exact setup depends on the chosen implementation.
+        // For this example, we'll assume getLogger() provides a working logger.
+    }
+}
+
+
+fun demonstrateLogging() {
+    // MyLoggerConfig.setup() // Call setup if needed by your logging backend
+
+    // Get a logger instance (typically by class or name)
+    val logger: Logger = getLogger("MyApplication") // Or getLogger(MyApplication::class.java)
+
+    logger.trace { "This is a trace message." } // Might not be visible if level is INFO
+    logger.debug { "This is a debug message." } // Might not be visible if level is INFO
+    logger.info("This is an info message.")
+    logger.warn("This is a warning message.", RuntimeException("Something to warn about"))
+    logger.error("This is an error message.", IllegalStateException("Critical failure!"))
+}
+```
+
+### Other Utilities
+
+`kuick-core` also bundles several other useful utilities:
+
+*   **`kuick.models`**:
+    *   `Id<T>`: A type-safe wrapper for entity identifiers, enhancing clarity and preventing accidental mixing of IDs from different models.
+    *   `Email`: A value class for representing email addresses, potentially with validation.
+    *   `Password`: A class for handling passwords, often with hashing capabilities (though hashing itself might be in a security-focused module).
+    *   `Named`: An interface for objects that have a `name` property.
+*   **`kuick.time`**:
+    *   `TimeProvider`: An interface for abstracting time, useful for testing.
+    *   `now`, `nowInstant`, `nowUnix`, `nowMillis`: Functions to get the current time in various formats.
+    *   Extensions for `kotlin.time.Duration`.
+*   **`kuick.utils`**:
+    *   `randomUUID()`: Generates a random UUID string.
+    *   String utilities (e.g., `capitalize`, `uncapitalize`, `camelCase`, `snakeCase`).
+    *   Collection utilities and other miscellaneous helper functions.
+
+**Example of using some utilities:**
+
+```kotlin
+import com.kuick.models.Email
+import com.kuick.models.Id
+import com.kuick.time.nowUnix
+import com.kuick.utils.randomUUID
+
+fun demonstrateUtilities() {
+    // IDs
+    val userId: Id<User> = Id("user-123") // Assuming User is defined as in Repository example
+    println("User ID: $userId")
+
+    // Email
+    try {
+        val email = Email("test@example.com")
+        println("Valid Email: $email")
+    } catch (e: IllegalArgumentException) {
+        println("Invalid Email: ${e.message}")
+    }
+
+
+    // Time
+    val currentUnixTime = nowUnix()
+    println("Current Unix Timestamp: $currentUnixTime")
+
+    // UUID
+    val uniqueId = randomUUID()
+    println("Generated UUID: $uniqueId")
+}
+```
+
+## How These Components Work Together
+
+The components in `kuick-core` are designed to be modular yet complementary:
+
+*   **Repositories** manage your data models (which might use `Id` from `kuick.models`).
+*   Expensive repository calls or business logic can be **cached** using the `CacheManager` to improve performance.
+*   **Events** from the `Bus` can be used to decouple actions, for instance, publishing an event after a user is created via a repository, allowing other parts of the system to react without direct coupling.
+*   Throughout your application, consistent **logging** helps in monitoring and debugging.
+*   Various **utilities** simplify common tasks like generating unique identifiers, handling time, or manipulating strings.
+
+By providing these fundamental pieces, `kuick-core` helps you build robust and maintainable applications more efficiently. You can pick and choose the components you need and integrate them with other Kuick libraries or third-party solutions.

--- a/kuick-repositories-jasync-sql/README.md
+++ b/kuick-repositories-jasync-sql/README.md
@@ -1,0 +1,119 @@
+# Kuick Repositories JAsync SQL
+
+`kuick-repositories-jasync-sql` provides a concrete implementation of the `kuick-core` repository pattern, leveraging the JAsync SQL library for asynchronous database access. This module is primarily designed for interacting with PostgreSQL databases in a non-blocking manner.
+
+## Key Features
+
+*   **Integration with `kuick-core`**: Seamlessly implements the `Repository<I, T>` and `ModelRepository<I, T>` interfaces from `kuick-core`.
+*   **Asynchronous Operations**: Utilizes JAsync SQL for fully asynchronous and non-blocking database calls, making it suitable for high-performance applications.
+*   **Connection Pooling**: Manages database connections efficiently using `JasyncPool`, which is a wrapper around JAsync's connection pool.
+*   **Environment-based Configuration**: `JasyncPool` can be easily configured using environment variables for database connection details (host, port, user, password, database name).
+
+## Dependencies
+
+This submodule relies on:
+
+*   `kuick-core`: For the core repository interfaces and models.
+*   `jasync-sql-postgresql`: The JAsync driver for PostgreSQL.
+
+## Usage Example
+
+Here's how you can use `kuick-repositories-jasync-sql` to interact with a PostgreSQL database:
+
+1.  **Define your data model**:
+
+    This model should typically implement `Model<I>` from `kuick-core`.
+
+    ```kotlin
+    import com.kuick.models.Id
+    import com.kuick.models.Model
+    import java.time.LocalDateTime
+
+    // Example: A simple 'Product' model
+    data class Product(
+        override val id: Id<Product> = Id(), // Auto-generated ID
+        val name: String,
+        val description: String?,
+        val price: Double,
+        val createdAt: LocalDateTime = LocalDateTime.now()
+    ) : Model<Id<Product>>
+    ```
+
+2.  **Set up environment variables for `JasyncPool`**:
+
+    Before running your application, ensure these environment variables are set:
+
+    ```bash
+    export DB_HOST=localhost
+    export DB_PORT=5432
+    export DB_USER=youruser
+    export DB_PASSWORD=yourpassword
+    export DB_NAME=yourdatabase
+    # Optional:
+    # export DB_POOL_MAX_ACTIVE_CONNECTIONS=10
+    # export DB_POOL_MAX_IDLE_TIME_MS=600000
+    # export DB_POOL_MAX_QUEUE_SIZE=100
+    ```
+
+3.  **Instantiate `JasyncPool` and `ModelRepositoryJasync`**:
+
+    ```kotlin
+    import com.kuick.core.db.ModelRepository
+    import com.kuick.repositories.jasyncsql.JasyncPool
+    import com.kuick.repositories.jasyncsql.ModelRepositoryJasync
+    import kotlinx.coroutines.runBlocking
+
+    // Placeholder for actual table definition and schema management
+    // In a real application, you would use a migration tool or ensure the table exists.
+    const val PRODUCTS_TABLE_NAME = "products" // Or your actual table name
+
+    suspend fun main() {
+        // 1. Create JasyncPool from environment variables
+        val pool = JasyncPool.fromEnvironment()
+
+        // 2. Create a ModelRepository for the Product model
+        //    Requires the table name and the KClass of the model.
+        val productRepository: ModelRepository<Id<Product>, Product> =
+            ModelRepositoryJasync(Product::class, pool.pool(), PRODUCTS_TABLE_NAME)
+
+        // 3. Perform database operations
+        try {
+            // Example: Insert a new product
+            val newProduct = Product(name = "Awesome Laptop", description = "High-performance laptop", price = 1200.99)
+            val insertedProduct = productRepository.insert(newProduct)
+            println("Inserted product: $insertedProduct")
+
+            // Example: Find the product by ID
+            val foundProduct = productRepository.findById(insertedProduct.id)
+            if (foundProduct != null) {
+                println("Found product by ID: $foundProduct")
+            } else {
+                println("Product with ID ${insertedProduct.id} not found.")
+            }
+
+            // Example: Get all products (use with caution on large tables)
+            val allProducts = productRepository.getAll()
+            println("All products (${allProducts.size}):")
+            allProducts.forEach { println("- $it") }
+
+        } catch (e: Exception) {
+            System.err.println("Database operation failed: ${e.message}")
+            e.printStackTrace()
+        } finally {
+            // Close the connection pool when the application shuts down
+            pool.close()
+            println("Connection pool closed.")
+        }
+    }
+
+    // To run this example (ensure PostgreSQL is running and configured):
+    // fun main() = runBlocking { main() }
+    ```
+
+    **Note on Table Schema**: `ModelRepositoryJasync` expects the corresponding database table to exist. You'll need to manage your database schema (e.g., using SQL migration tools like Flyway or Liquibase) to create tables like `products` with appropriate columns matching your model (`id`, `name`, `description`, `price`, `createdAt`).
+
+## JVM Specific
+
+Please note that `kuick-repositories-jasync-sql` is a JVM-specific module because JAsync SQL is a Java library. It is not suitable for Kotlin Multiplatform projects targeting non-JVM platforms.
+
+This module is ideal for backend services and applications running on the JVM that require efficient, asynchronous communication with PostgreSQL.


### PR DESCRIPTION
This commit introduces README.md files for the following submodules:
- kuick-core: Details its rich set of utilities including repositories, caching, event bus, and logging.
- kuick-api-rpc: Explains its role in facilitating RPC-style communication.
- kuick-repositories-jasync-sql: Describes its JAsync-based SQL implementation for kuick-core repositories.

Additionally, the global README.md has been updated to:
- Provide an overview of the Kuick project.
- Link to each of the new submodule READMEs.
- Offer general guidance for getting started and contributing.

These READMEs aim to improve the project's documentation from a consumer's perspective, explaining the purpose, usage, and providing examples for each library.