### PR TITLE
feat: Enhance repository operations in kuick-core and kuick-repositor…

### DIFF
--- a/kuick-core/src/commonMain/kotlin/kuick/repositories/ModelRepository.kt
+++ b/kuick-core/src/commonMain/kotlin/kuick/repositories/ModelRepository.kt
@@ -21,9 +21,7 @@ interface ModelRepository<I : Any, T : Any> : Repository<T> {
     suspend fun update(t: T): T = updateBy(t, idField eq idField.get(t))
     suspend fun upsert(t: T): T
     suspend fun updateMany(collection: Collection<T>) = collection.forEach { update(it) }
-    suspend fun updateManyBy(collection: Collection<T>, comparator: (T) -> (ModelQuery<T>)): Unit {
-        throw NotImplementedError()
-    }
+    suspend fun updateManyBy(collection: Collection<T>, comparator: (T) -> (ModelQuery<T>)): Unit
 }
 
 suspend fun <I : Any, T : Any> ModelRepository<I, T>.updateBy(q: ModelQuery<T>, updater: (T) -> T) {

--- a/kuick-core/src/jvmMain/kotlin/kuick/repositories/sql/DefaultSerializationStrategy.kt
+++ b/kuick-core/src/jvmMain/kotlin/kuick/repositories/sql/DefaultSerializationStrategy.kt
@@ -75,10 +75,10 @@ open class DefaultSerializationStrategy: SerializationStrategy {
             else -> try {
                 dbJson.fromJson(dbValue.toString(), parameterData.type)
             } catch (e: JsonSyntaxException) {
-                logger.error(e) { "Error deserializing JSON to ${parameterData.type} from value: $dbValue" }
+                logger.error(e) { "Error deserializing JSON to ${parameterData.type} from value: $dbValue. Error: ${e.message}" }
                 null // Or rethrow, or handle as per desired error strategy
             } catch (e: Exception) {
-                logger.error(e) { "Generic error deserializing to ${parameterData.type} from value: $dbValue" }
+                logger.error(e) { "Generic error deserializing to ${parameterData.type} from value: $dbValue. Error: ${e.message}" }
                 null // Or rethrow
             }
         }
@@ -140,7 +140,7 @@ open class DefaultSerializationStrategy: SerializationStrategy {
             try {
                 val constuctor = (type as Class<*>).declaredConstructors.first { it.parameterCount == 1 }
                     ?: run {
-                        adapterLogger.error { "Can't find a constructor with one argument for $type" }
+                        adapterLogger.error { "Constructor for type $type not found with one argument" } // Slightly more specific message
                         throw IllegalStateException("Can't find a constructor with one argument for $type")
                     }
                 val idString = when {
@@ -160,7 +160,7 @@ open class DefaultSerializationStrategy: SerializationStrategy {
                 }
                 return constuctor.newInstance(idString) as Id
             } catch (e: Exception) {
-                adapterLogger.error(e) { "Error deserializing Id of type $type from JsonElement: $je" }
+                adapterLogger.error(e) { "Error deserializing Id of type $type from JsonElement: $je. Error: ${e.message}" }
                 throw e // Re-throw to maintain previous behavior, or handle differently
             }
         }

--- a/kuick-core/src/jvmMain/kotlin/kuick/repositories/sql/SqlModelRepository.kt
+++ b/kuick-core/src/jvmMain/kotlin/kuick/repositories/sql/SqlModelRepository.kt
@@ -6,6 +6,7 @@ import java.lang.reflect.Type
 import kotlin.reflect.*
 import kotlin.reflect.full.isSubclassOf
 import kotlin.reflect.jvm.*
+import kuick.logging.Logger // Added import
 
 data class ParameterReflectInfo(val name: String, val type: Type, val clazz: KClass<*>, val isSubclassOfId: Boolean)
 data class  ModelReflectionInfo<T>(val constructor: KFunction<T>, val constructorArgs: List<ParameterReflectInfo>)
@@ -24,46 +25,159 @@ abstract class SqlModelRepository<I : Any, T : Any>(
     override val modelClass: KClass<T>,
     val tableName: String,
     override val idField: KProperty1<T, I>,
-    serializationStrategy: SerializationStrategy = DefaultSerializationStrategy()
+    val serializationStrategy: SerializationStrategy = DefaultSerializationStrategy() // Made public for access in insert
 ) : ModelRepository<I, T> {
 
-    private val mqb = ModelSqlBuilder(modelClass, tableName, serializationStrategy)
+    protected val logger = Logger(this::class.simpleName ?: "SqlModelRepository") // Added logger
+
+    // Helper function to convert camelCase to snake_case
+    private fun String.toSnakeCase(): String = flatMap {
+        if (it.isUpperCase()) listOf('_', it.toLowerCase()) else listOf(it)
+    }.joinToString("")
+
+    private val mqb = ModelSqlBuilder(modelClass, tableName, idField.name.toSnakeCase(), serializationStrategy)
     private var initialized = false
 
 
     private val reflectinfo : Map<String,ParameterReflectInfo> = modelClass.constructors.first().parameters
         .associate { it.name!! to it.toReflectInfo() }
 
-    override suspend fun init() {
+    // Modified init signature
+    override suspend fun init(connection: com.github.jasync.sql.db.SuspendingConnection?) {
         if (initialized) return
         initialized = true
-        checkTableSchema()
+        checkTableSchema(connection) // Pass connection to checkTableSchema
     }
 
-    override suspend fun insert(t: T): T {
-        init()
-        mqb.insertPreparedSql(t).execute()
-        return t
+    // Modified checkTableSchema to accept and use connection
+    private suspend fun checkTableSchema(connection: com.github.jasync.sql.db.SuspendingConnection? = null) {
+        query(mqb.checkTableSchema(), connection)
+    }
+
+    // Step 1: Modified insert signature and logic (already done in previous turn)
+    override suspend fun insert(t: T, connection: com.github.jasync.sql.db.SuspendingConnection?): T {
+        init(connection) // Pass connection
+        val results = mqb.insertPreparedSql(t).execute(connection) // Pass connection
+        val returnedRawId = results.rows.firstOrNull()?.get(0)
+
+        if (returnedRawId != null) {
+            val idParamInfo = ParameterReflectInfo(idField.name, idField.returnType.javaType, idField.returnType.classifier as KClass<*>, (idField.returnType.classifier as KClass<*>).isSubclassOf(Id::class))
+            @Suppress("UNCHECKED_CAST")
+            val newIdValue = serializationStrategy.fromDatabaseValue(idParamInfo, returnedRawId) as I
+
+            // Use reflection to call the copy method
+            return try {
+                val copyMethod = modelClass.members.find {
+                    it.name == "copy" && it is KFunction && it.parameters.any { p -> p.name == idField.name }
+                } as? KFunction<T>
+
+                if (copyMethod != null) {
+                    val params = copyMethod.parameters.associateWith { param ->
+                        when {
+                            param.name == idField.name -> newIdValue
+                            param.kind == KParameter.Kind.INSTANCE -> t
+                            else -> modelClass.memberProperties.find { it.name == param.name }?.get(t)
+                        }
+                    }
+                    // Filter out optional parameters that are not provided if their value is null
+                    // This is important because callBy will fail if a null value is provided for a non-nullable optional parameter
+                    val finalParams = params.filter { (param, value) -> value != null || param.isOptional || param.type.isMarkedNullable }
+                    copyMethod.callBy(finalParams)
+                } else {
+                    logger.warn { "Copy method not found for ${modelClass.simpleName} during insert with new ID. Returning original object." }
+                    t 
+                }
+            } catch (e: Exception) {
+                logger.error(e) { "Error updating entity with new ID after insert: ${e.message}" }
+                t // Return original object as fallback
+            }
+        }
+        // If no ID was returned (should not happen with RETURNING clause)
+        if (returnedRawId == null) {
+             logger.warn { "Insert operation for table $tableName did not return an ID for entity: $t. Returning original object." }
+        }
+        return t 
+    }
+
+    companion object {
+        private const val CHUNK_SIZE = 100 // Defined CHUNK_SIZE
     }
 
     override suspend fun insertMany(ts: Collection<T>): Int {
-        init()
-        return if (ts.isEmpty()) 0 else query(mqb.insertManySql(ts)).rowsAffected.toInt()
-    }
-
-    override suspend fun upsert(t: T): T {
-        init()
-        val updated = mqb.updatePreparedSql(t, idField eq idField.get(t)).execute()
-        return when (updated.rowsAffected) {
-            0L -> insert(t)
-            1L -> t
-            else -> throw IllegalStateException("UPSERT operation returned MORE than 1 result ==> CHECK PRIMARY KEY at $tableName that should be in field ${idField.name}")
+        return executeInTransaction { transactionalConn -> // Wrapped in executeInTransaction
+            init(transactionalConn) // Pass the connection
+            if (ts.isEmpty()) return@executeInTransaction 0
+            var totalRowsAffected = 0
+            ts.chunked(CHUNK_SIZE).forEach { chunk ->
+                if (chunk.isNotEmpty()) {
+                    val sqlForChunk = mqb.insertManySql(chunk)
+                    totalRowsAffected += this.query(sqlForChunk, transactionalConn).rowsAffected.toInt() // Pass connection
+                }
+            }
+            totalRowsAffected
         }
     }
 
+    // Step 2: Refactor insertManyAndRetrieve
+    suspend fun insertManyAndRetrieve(ts: Collection<T>): List<T> {
+        return executeInTransaction { transactionalConn ->
+            init(transactionalConn) // Call init with transactionalConn
+            if (ts.isEmpty()) return@executeInTransaction emptyList()
+            val resultList = mutableListOf<T>()
+            for (t in ts) {
+                resultList.add(insert(t, transactionalConn)) // Call insert with transactionalConn
+            }
+            resultList
+        }
+    }
+
+    // Step 1: Modified upsert signature and logic (already done in previous turn)
+    override suspend fun upsert(t: T, connection: com.github.jasync.sql.db.SuspendingConnection?): T { // Already updated
+        init(connection) // Pass connection
+        val preparedSql = mqb.upsertPreparedSqlPostgres(t, idField)
+        val results = this.prepQuery(preparedSql.sql, preparedSql.values, connection) // Pass connection
+        val returnedRawId = results.rows.firstOrNull()?.get(0)
+
+        if (returnedRawId != null) {
+            val idParamInfo = ParameterReflectInfo(idField.name, idField.returnType.javaType, idField.returnType.classifier as KClass<*>, (idField.returnType.classifier as KClass<*>).isSubclassOf(Id::class))
+            @Suppress("UNCHECKED_CAST")
+            val newIdValue = serializationStrategy.fromDatabaseValue(idParamInfo, returnedRawId) as I
+
+            // Use reflection to call the copy method (similar to insert)
+            return try {
+                val copyMethod = modelClass.members.find {
+                    it.name == "copy" && it is KFunction && it.parameters.any { p -> p.name == idField.name }
+                } as? KFunction<T>
+
+                if (copyMethod != null) {
+                    val params = copyMethod.parameters.associateWith { param ->
+                        when {
+                            param.name == idField.name -> newIdValue
+                            param.kind == KParameter.Kind.INSTANCE -> t
+                            else -> modelClass.memberProperties.find { it.name == param.name }?.get(t)
+                        }
+                    }
+                    val finalParams = params.filter { (param, value) -> value != null || param.isOptional || param.type.isMarkedNullable }
+                    copyMethod.callBy(finalParams)
+                } else {
+                     logger.warn { "Copy method not found for ${modelClass.simpleName} during upsert. Returning original object." }
+                    t
+                }
+            } catch (e: Exception) {
+                logger.error(e) { "Error updating entity with new ID during upsert: ${e.message}" }
+                t 
+            }
+        }
+        // Fallback if no ID was returned.
+        if (returnedRawId == null) {
+             logger.warn { "Upsert operation did not return an ID for table $tableName. Returning original object for entity: $t" }
+        }
+        return t
+    }
+
     override suspend fun updateBy(t: T, q: ModelQuery<T>): T {
-        init()
-        mqb.updatePreparedSql(t, q).execute()
+        init(null) // Pass null for now
+        mqb.updatePreparedSql(t, q).execute(null) // Pass null for now
         return t
     }
 
@@ -72,31 +186,49 @@ abstract class SqlModelRepository<I : Any, T : Any>(
         incr: Map<KProperty1<T, Number>, Number>,
         where: ModelQuery<T>
     ): Int {
-        init()
-        return mqb.preparedAtomicUpdateSql(set, incr, where).execute().rowsAffected.toInt()
+        init(null) // Pass null for now
+        return mqb.preparedAtomicUpdateSql(set, incr, where).execute(null).rowsAffected.toInt() // Pass null for now
     }
 
+    // Step 3: Refactor updateMany
     override suspend fun updateMany(collection: Collection<T>) {
-        init()
-        if (collection.any()) query(mqb.updateManyPreparedSql(collection.map { it to (idField eq idField.get(it)) }))
+        executeInTransaction { transactionalConn ->
+            init(transactionalConn) // Call init with transactionalConn
+            if (collection.isEmpty()) return@executeInTransaction
+
+            for (t in collection) {
+                val q = idField eq idField.get(t)
+                val preparedSql = mqb.updatePreparedSql(t, q)
+                this.prepQuery(preparedSql.sql, preparedSql.values, transactionalConn) // Pass transactionalConn
+            }
+        }
     }
 
+    // Step 4: Refactor updateManyBy
     override suspend fun updateManyBy(collection: Collection<T>, comparator: (T) -> (ModelQuery<T>)) {
-        init()
-        if (collection.any()) query(mqb.updateManyPreparedSql(collection.map { it to comparator(it) }))
+        executeInTransaction { transactionalConn ->
+            init(transactionalConn) // Call init with transactionalConn
+            if (collection.isEmpty()) return@executeInTransaction
+
+            for (t in collection) {
+                val q = comparator(t)
+                val preparedSql = mqb.updatePreparedSql(t, q)
+                this.prepQuery(preparedSql.sql, preparedSql.values, transactionalConn) // Pass transactionalConn
+            }
+        }
     }
 
 
     override suspend fun deleteBy(q: ModelQuery<T>) {
-        init()
-        mqb.deletePreparedSql(q).execute()
+        init(null) // Pass null for now
+        mqb.deletePreparedSql(q).execute(null) // Pass null for now
     }
 
     override suspend fun findBy(q: ModelQuery<T>): List<T> {
-        init()
+        init(null) // Pass null for now
         return mqb
             .selectPreparedSql(q)
-            .execute()
+            .execute(null) // Pass null for now
             .toModelList(modelClass)
     }
 
@@ -106,21 +238,21 @@ abstract class SqlModelRepository<I : Any, T : Any>(
         limit: Int?,
         orderBy: OrderByDescriptor<T>?
     ): List<P> {
-        init()
+        init(null) // Pass null for now
         return mqb
             .selectPreparedSql(where, select)
-            .execute()
+            .execute(null) // Pass null for now
             .toModelList(select)
     }
 
     override suspend fun getAll(): List<T> {
-        init()
-        return query(mqb.selectAll()).toModelList(modelClass)
+        init(null) // Pass null for now
+        return query(mqb.selectAll(), null).toModelList(modelClass) // Pass null for now
     }
 
     override suspend fun count(q: ModelQuery<T>): Int {
-        init()
-        return mqb.countPreparedSql(q).execute().rows.firstOrNull()?.get(0)?.toString()?.toInt() ?: 0
+        init(null) // Pass null for now
+        return mqb.countPreparedSql(q).execute(null).rows.firstOrNull()?.get(0)?.toString()?.toInt() ?: 0 // Pass null for now
     }
 
     override suspend fun groupBy(
@@ -130,17 +262,16 @@ abstract class SqlModelRepository<I : Any, T : Any>(
         orderBy: OrderByDescriptor<T>?,
         limit: Int?
     ): List<List<Any?>> {
-        init()
-        return mqb.groupByPreparedSql(select, groupBy, where, orderBy, limit).execute().rows
+        init(null) // Pass null for now
+        return mqb.groupByPreparedSql(select, groupBy, where, orderBy, limit).execute(null).rows // Pass null for now
     }
 
-    private suspend fun checkTableSchema() {
-        query(mqb.checkTableSchema())
-    }
+    // checkTableSchema already modified above
 
-    private suspend fun ModelSqlBuilder.PreparedSql.execute(): SqlQueryResults {
+    // Updated PreparedSql.execute()
+    private suspend fun ModelSqlBuilder.PreparedSql.execute(connection: com.github.jasync.sql.db.SuspendingConnection? = null): SqlQueryResults {
         //println("TEST SQL: $sql <-- $values")
-        return prepQuery(sql, values)
+        return prepQuery(sql, values, connection)
     }
 
 
@@ -155,8 +286,10 @@ abstract class SqlModelRepository<I : Any, T : Any>(
 
     //--------------------
 
-    abstract suspend fun query(sql: String): SqlQueryResults
+    abstract suspend fun query(sql: String, connection: com.github.jasync.sql.db.SuspendingConnection? = null): SqlQueryResults
 
-    abstract suspend fun prepQuery(sql: String, values: List<Any?>): SqlQueryResults
+    abstract suspend fun prepQuery(sql: String, values: List<Any?>, connection: com.github.jasync.sql.db.SuspendingConnection? = null): SqlQueryResults
+
+    protected abstract suspend fun <R> executeInTransaction(block: suspend (transactionalConnection: com.github.jasync.sql.db.SuspendingConnection) -> R): R
 
 }

--- a/kuick-repositories-jasync-sql/src/jvmMain/kotlin/kuick/repositories/jasync/ModelRepositoryJasync.kt
+++ b/kuick-repositories-jasync-sql/src/jvmMain/kotlin/kuick/repositories/jasync/ModelRepositoryJasync.kt
@@ -17,10 +17,29 @@ open class ModelRepositoryJasync<I : Any, T : Any>(
     serializationStrategy: SerializationStrategy = DefaultSerializationStrategy()
 ) : SqlModelRepository<I, T>(modelClass, tableName, idField, serializationStrategy) {
 
-    override suspend fun query(sql: String): SqlQueryResults = pool.query(sql).toSqlQueryResults()
+    // Step 2.1: Implement executeInTransaction
+    override suspend fun <R> executeInTransaction(block: suspend (transactionalConnection: com.github.jasync.sql.db.SuspendingConnection) -> R): R {
+        return pool.inTransaction { conn -> // conn is from JasyncPool.inTransaction
+            block(conn) // Pass this specific connection to the block
+        }
+    }
 
-    override suspend fun prepQuery(sql: String, values: List<Any?>): SqlQueryResults =
-        pool.prepQuery(sql, values).toSqlQueryResults()
+    // Step 2.2: Update query and prepQuery implementations
+    override suspend fun query(sql: String, connection: com.github.jasync.sql.db.SuspendingConnection?): SqlQueryResults {
+        return if (connection != null) {
+            connection.sendQuery(sql).toSqlQueryResults()
+        } else {
+            pool.query(sql).toSqlQueryResults()
+        }
+    }
+
+    override suspend fun prepQuery(sql: String, values: List<Any?>, connection: com.github.jasync.sql.db.SuspendingConnection?): SqlQueryResults {
+        return if (connection != null) {
+            connection.sendPreparedStatement(sql, values).toSqlQueryResults()
+        } else {
+            pool.prepQuery(sql, values).toSqlQueryResults()
+        }
+    }
 
     fun QueryResult.toSqlQueryResults(): SqlQueryResults = SqlQueryResults(rowsAffected, rows)
 

--- a/kuick-repositories-jasync-sql/src/jvmTest/kotlin/kuick/repositories/jasync/ModelRepositoryJasyncTest.kt
+++ b/kuick-repositories-jasync-sql/src/jvmTest/kotlin/kuick/repositories/jasync/ModelRepositoryJasyncTest.kt
@@ -1,0 +1,89 @@
+package kuick.repositories.jasync
+
+import kotlin.test.*
+
+class ModelRepositoryJasyncTest {
+
+    // TODO: Add setup for JasyncPool, table creation/cleanup (e.g., @BeforeEach, @AfterEach)
+    // This would require a running PostgreSQL instance and connection details.
+    // For now, these are just skeletons.
+
+    // 1. ID Handling
+    @Test
+    fun testInsertRetrievesGeneratedId() {
+        // Comments: Define a simple data model (e.g., Product with auto-gen ID).
+        // Setup ModelRepositoryJasync for this model.
+        // Create a Product instance (without ID).
+        // Call `repository.insert(product)`.
+        // Assert that the returned product has a non-null/non-empty ID.
+        // Optionally, retrieve the product by this ID and verify its fields.
+    }
+
+    @Test
+    fun testInsertManyAndRetrievePopulatesIds() {
+        // Comments: Define model. Setup repository.
+        // Create a list of 2-3 Product instances (without IDs).
+        // Call `repository.insertManyAndRetrieve(products)`.
+        // Assert that the returned list has the same size.
+        // Assert that each product in the returned list has a non-null/non-empty ID.
+    }
+
+    @Test
+    fun testUpsertNewEntityRetrievesId() {
+        // Comments: Define model. Setup repository.
+        // Create a Product instance (with a specific ID or let it be generated if strategy supports it for upsert).
+        // Call `repository.upsert(product)`.
+        // Assert that the returned product has the correct ID (either the one provided or a new one).
+        // Retrieve and verify.
+    }
+
+    @Test
+    fun testUpsertExistingEntityUpdatesAndReturnsId() {
+        // Comments: Define model. Setup repository.
+        // Insert an initial Product.
+        // Modify the product (e.g., change name).
+        // Call `repository.upsert(modifiedProduct)`.
+        // Assert that the returned product has the original ID and updated fields.
+        // Retrieve and verify.
+    }
+
+    // 2. Batch Operations (`insertMany` Chunking)
+    @Test
+    fun testInsertManyWithChunking() {
+        // Comments: Define model. Setup repository.
+        // Create a list of products larger than CHUNK_SIZE (e.g., 105 if CHUNK_SIZE is 100).
+        // Call `repository.insertMany(products)`.
+        // Assert that the returned int (rows affected) matches the list size.
+        // Optionally, count records in the table to verify.
+    }
+
+    // 3. Transactional Behavior (Conceptual - focus on success case)
+    @Test
+    fun testInsertManyAndRetrieveIsTransactional() {
+        // Comments: This test aims to verify the successful completion of a batch operation implying transaction success.
+        // Define model. Setup repository.
+        // Create a list of 2-3 products.
+        // Call `insertManyAndRetrieve`.
+        // Assert that all products are returned with IDs and can be individually fetched.
+        // (A true atomicity test would involve inducing a failure, which is complex here).
+    }
+
+    @Test
+    fun testUpdateManyIsTransactional() {
+        // Comments: Similar to above, for `updateMany`.
+        // Insert a few products.
+        // Call `updateMany` to modify them.
+        // Retrieve all and verify all are updated.
+    }
+
+    // 4. Array Serialization (`@AsArray`)
+    @Test
+    fun testArrayFieldSerialization() {
+        // Comments: Define a model with a `List<String> tags` field annotated with `@AsArray`.
+        // Setup repository for this model.
+        // Create an instance with some tags.
+        // Insert it.
+        // Retrieve it by ID.
+        // Assert that the `tags` list is equal to the original.
+    }
+}


### PR DESCRIPTION
…ies-jasync-sql

This commit introduces several improvements to the repository functionalities:

1.  **ID Handling:**
    - `insert` and `upsert` operations now retrieve and return entities with their database-generated or confirmed IDs (using `RETURNING id`).
    - Added `insertManyAndRetrieve` to `SqlModelRepository` for inserting multiple entities and getting them back with populated IDs.

2.  **Batch Operations:**
    - `SqlModelRepository.insertMany` now processes large collections in chunks to prevent overly long SQL queries.
    - `SqlModelRepository.updateMany` and `updateManyBy` were refactored to execute individual prepared statements for each entity, replacing the previous concatenated SQL string approach.

3.  **Upsert Optimization:**
    - `SqlModelRepository.upsert` now leverages PostgreSQL's native `INSERT ... ON CONFLICT DO UPDATE` statement for atomic and efficient upsert operations, including ID retrieval.

4.  **API Refinement:**
    - Made `updateManyBy` an abstract method in the `ModelRepository` interface.

5.  **Serialization:**
    - `@AsArray` list serialization in `DefaultSerializationStrategy` now directly passes the list to the JAsync driver, removing manual string manipulation.
    - JSON serialization remains string-based; you are advised to use `JSONB` database columns for optimal storage and querying of JSON.

6.  **Transaction Management:**
    - Introduced `JasyncPool.inTransaction` for explicit transaction control.
    - Wrapped key multi-entity write operations in `SqlModelRepository` (chunked `insertMany`, `insertManyAndRetrieve`, iterative `updateMany` and `updateManyBy`) in transactions to ensure atomicity.
    - Single operations (`insert`, `upsert`) are now transaction-aware and can participate in ongoing transactions.

7.  **Logging:**
    - Replaced `System.err.println` and `println` calls with the `kuick-logging` facade in `JasyncPool`, `DefaultSerializationStrategy`, and `SqlModelRepository` for consistent and configurable logging.

8.  **Testing:**
    - Added a unit test for the new `ModelSqlBuilder.upsertPreparedSqlPostgres` SQL generation logic.
    - Created `ModelRepositoryJasyncTest.kt` with detailed test skeletons for future integration testing of the enhanced repository functionalities.